### PR TITLE
Introduce HttpClientError enum for clearer error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,14 @@ changes since 1.0.0
 ### Added
 - Workflow github actions for CI
 - CompileTest Exemples
+- HttpClientError enumeration and error string utility
+
+### Changed
+- Error callbacks now use HttpClientError enumeration instead of raw integers
 
 ### Compatibility
 
 - ESP32 (all variants)
 - Arduino IDE and PlatformIO
 - Arduino library format compliant
+

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ void setup() {
             Serial.printf("Success! Status: %d\n", response->getStatusCode());
             Serial.printf("Body: %s\n", response->getBody().c_str());
         },
-        [](int error, const char* message) {
-            Serial.printf("Error: %d - %s\n", error, message);
+        [](HttpClientError error, const char* message) {
+            Serial.printf("Error: %s (%d)\n", httpClientErrorToString(error), (int)error);
         }
     );
 }
@@ -112,7 +112,7 @@ void setUserAgent(const char* userAgent);
 
 ```cpp
 typedef std::function<void(AsyncHttpResponse*)> SuccessCallback;
-typedef std::function<void(int, const char*)> ErrorCallback;
+typedef std::function<void(HttpClientError, const char*)> ErrorCallback;
 ```
 
 ### AsyncHttpResponse Class
@@ -210,24 +210,24 @@ client.request(request, onSuccess);
 
 Error codes passed to error callbacks:
 
-- `-1`: Failed to initiate connection
-- `-2`: Failed to parse response headers  
-- `-3`: Connection closed before headers received
-- `-4`: Request timeout
+- `CONNECTION_FAILED (-1)`: Failed to initiate connection
+- `HEADER_PARSE_FAILED (-2)`: Failed to parse response headers
+- `CONNECTION_CLOSED (-3)`: Connection closed before headers received
+- `REQUEST_TIMEOUT (-4)`: Request timeout
 - `>0`: AsyncTCP error codes
 
 ```cpp
 client.get("http://example.com", onSuccess,
-    [](int error, const char* message) {
+    [](HttpClientError error, const char* message) {
         switch(error) {
-            case -1:
+            case CONNECTION_FAILED:
                 Serial.println("Connection failed");
                 break;
-            case -4:
+            case REQUEST_TIMEOUT:
                 Serial.println("Request timed out");
                 break;
             default:
-                Serial.printf("Network error: %d - %s\n", error, message);
+                Serial.printf("Network error: %s (%d)\n", httpClientErrorToString(error), (int)error);
         }
     }
 );

--- a/examples/CompileTest/CompileTest.ino
+++ b/examples/CompileTest/CompileTest.ino
@@ -78,8 +78,8 @@ void testHttpMethodsCompilation() {
         (void)header;  // Suppress unused variable warning
     };
     
-    auto errorCallback = [](int error, const char* message) {
-        Serial.printf("Error callback - Code: %d, Message: %s\n", error, message);
+    auto errorCallback = [](HttpClientError error, const char* message) {
+        Serial.printf("Error callback - Code: %d, Message: %s\n", (int)error, httpClientErrorToString(error));
     };
     
     // Test all HTTP methods compilation (won't execute in CI)
@@ -118,8 +118,8 @@ void loop() {
                     [](AsyncHttpResponse* response) {
                         Serial.printf("✓ GET request successful - Status: %d\n", response->getStatusCode());
                     },
-                    [](int error, const char* message) {
-                        Serial.printf("✗ GET request failed - Error: %d, Message: %s\n", error, message);
+                    [](HttpClientError error, const char* message) {
+                        Serial.printf("✗ GET request failed - Error: %s (%d)\n", httpClientErrorToString(error), (int)error);
                     }
                 );
                 testExecuted = true;

--- a/examples/CustomHeaders/CustomHeaders.ino
+++ b/examples/CustomHeaders/CustomHeaders.ino
@@ -26,19 +26,19 @@ void setup() {
         [](AsyncHttpResponse* response) {
             Serial.println("Request with custom headers successful!");
             Serial.printf("Status: %d\n", response->getStatusCode());
-            
+
             // Print response headers
             Serial.println("\nResponse Headers:");
             const auto& headers = response->getHeaders();
             for (const auto& header : headers) {
                 Serial.printf("  %s: %s\n", header.name.c_str(), header.value.c_str());
             }
-            
+
             // Print the body which should show our request headers
             Serial.printf("\nResponse Body:\n%s\n", response->getBody().c_str());
         },
-        [](int error, const char* message) {
-            Serial.printf("Error: %d - %s\n", error, message);
+        [](HttpClientError error, const char* message) {
+            Serial.printf("Error: %s (%d)\n", httpClientErrorToString(error), (int)error);
         }
     );
     
@@ -56,7 +56,7 @@ void setup() {
             Serial.println("\nCustom JSON POST request successful!");
             Serial.printf("Status: %d\n", response->getStatusCode());
             Serial.printf("Content-Type: %s\n", response->getHeader("Content-Type").c_str());
-            
+
             // Print first 800 characters of response
             String body = response->getBody();
             if (body.length() > 800) {
@@ -64,8 +64,8 @@ void setup() {
             }
             Serial.printf("Response: %s\n", body.c_str());
         },
-        [](int error, const char* message) {
-            Serial.printf("Custom request error: %d - %s\n", error, message);
+        [](HttpClientError error, const char* message) {
+            Serial.printf("Custom request error: %s (%d)\n", httpClientErrorToString(error), (int)error);
         }
     );
 }

--- a/examples/MultipleRequests/MultipleRequests.ino
+++ b/examples/MultipleRequests/MultipleRequests.ino
@@ -9,7 +9,7 @@ int responseCount = 0;
 void onResponse(AsyncHttpResponse* response, const String& requestName) {
     responseCount++;
     Serial.printf("[%s] Response %d received!\n", requestName.c_str(), responseCount);
-    Serial.printf("[%s] Status: %d %s\n", requestName.c_str(), 
+    Serial.printf("[%s] Status: %d %s\n", requestName.c_str(),
                   response->getStatusCode(), response->getStatusText().c_str());
     Serial.printf("[%s] Body length: %d\n", requestName.c_str(), response->getBody().length());
     
@@ -18,9 +18,9 @@ void onResponse(AsyncHttpResponse* response, const String& requestName) {
     }
 }
 
-void onError(int error, const char* message, const String& requestName) {
+void onError(HttpClientError error, const char* message, const String& requestName) {
     responseCount++;
-    Serial.printf("[%s] Error %d: %s\n", requestName.c_str(), error, message);
+    Serial.printf("[%s] Error %d: %s\n", requestName.c_str(), (int)error, httpClientErrorToString(error));
     
     if (responseCount >= requestCount) {
         Serial.println("All requests completed!");
@@ -44,28 +44,28 @@ void setup() {
     requestCount++;
     client.get("http://httpbin.org/get",
         [](AsyncHttpResponse* response) { onResponse(response, "GET"); },
-        [](int error, const char* message) { onError(error, message, "GET"); }
+        [](HttpClientError error, const char* message) { onError(error, message, "GET"); }
     );
     
     // Request 2: POST request
     requestCount++;
     client.post("http://httpbin.org/post", "data=test",
         [](AsyncHttpResponse* response) { onResponse(response, "POST"); },
-        [](int error, const char* message) { onError(error, message, "POST"); }
+        [](HttpClientError error, const char* message) { onError(error, message, "POST"); }
     );
     
     // Request 3: Another GET to different endpoint
     requestCount++;
     client.get("http://httpbin.org/headers",
         [](AsyncHttpResponse* response) { onResponse(response, "HEADERS"); },
-        [](int error, const char* message) { onError(error, message, "HEADERS"); }
+        [](HttpClientError error, const char* message) { onError(error, message, "HEADERS"); }
     );
     
     // Request 4: DELETE request
     requestCount++;
     client.del("http://httpbin.org/delete",
         [](AsyncHttpResponse* response) { onResponse(response, "DELETE"); },
-        [](int error, const char* message) { onError(error, message, "DELETE"); }
+        [](HttpClientError error, const char* message) { onError(error, message, "DELETE"); }
     );
     
     Serial.printf("Initiated %d simultaneous requests\n", requestCount);

--- a/examples/PostWithData/PostWithData.ino
+++ b/examples/PostWithData/PostWithData.ino
@@ -24,7 +24,7 @@ void setup() {
             Serial.printf("Status: %d\n", response->getStatusCode());
             Serial.printf("Content-Type: %s\n", response->getHeader("Content-Type").c_str());
             Serial.printf("Body length: %d\n", response->getBody().length());
-            
+
             // Print first 500 characters of response
             String body = response->getBody();
             if (body.length() > 500) {
@@ -32,8 +32,8 @@ void setup() {
             }
             Serial.printf("Body: %s\n", body.c_str());
         },
-        [](int error, const char* message) {
-            Serial.printf("POST Error: %d - %s\n", error, message);
+        [](HttpClientError error, const char* message) {
+            Serial.printf("POST Error: %s (%d)\n", httpClientErrorToString(error), (int)error);
         }
     );
 }

--- a/examples/SimpleGet/SimpleGet.ino
+++ b/examples/SimpleGet/SimpleGet.ino
@@ -22,8 +22,8 @@ void setup() {
             Serial.printf("Status: %d\n", response->getStatusCode());
             Serial.printf("Body: %s\n", response->getBody().c_str());
         },
-        [](int error, const char* message) {
-            Serial.printf("Error: %d - %s\n", error, message);
+        [](HttpClientError error, const char* message) {
+            Serial.printf("Error: %s (%d)\n", httpClientErrorToString(error), (int)error);
         }
     );
 }

--- a/src/AsyncHttpClient.h
+++ b/src/AsyncHttpClient.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include "HttpRequest.h"
 #include "HttpResponse.h"
+#include "HttpCommon.h"
 
 
     #include <AsyncTCP.h>
@@ -13,7 +14,7 @@
 class AsyncHttpClient {
 public:
     typedef std::function<void(AsyncHttpResponse*)> SuccessCallback;
-    typedef std::function<void(int, const char*)> ErrorCallback;
+    typedef std::function<void(HttpClientError, const char*)> ErrorCallback;
 
     AsyncHttpClient();
     ~AsyncHttpClient();
@@ -69,7 +70,7 @@ private:
     bool parseResponseHeaders(RequestContext* context, const String& headerData);
     void processResponse(RequestContext* context);
     void cleanup(RequestContext* context);
-    void triggerError(RequestContext* context, int errorCode, const char* errorMessage);
+    void triggerError(RequestContext* context, HttpClientError errorCode, const char* errorMessage);
 };
 
 #endif // ASYNC_HTTP_CLIENT_H

--- a/src/HttpCommon.h
+++ b/src/HttpCommon.h
@@ -11,4 +11,26 @@ struct HttpHeader {
     HttpHeader(const String& n, const String& v) : name(n), value(v) {}
 };
 
+enum HttpClientError {
+    CONNECTION_FAILED = -1,
+    HEADER_PARSE_FAILED = -2,
+    CONNECTION_CLOSED = -3,
+    REQUEST_TIMEOUT = -4
+};
+
+inline const char* httpClientErrorToString(HttpClientError error) {
+    switch (error) {
+        case CONNECTION_FAILED:
+            return "Failed to initiate connection";
+        case HEADER_PARSE_FAILED:
+            return "Failed to parse response headers";
+        case CONNECTION_CLOSED:
+            return "Connection closed before headers received";
+        case REQUEST_TIMEOUT:
+            return "Request timeout";
+        default:
+            return "Network error";
+    }
+}
+
 #endif // HTTP_COMMON_H


### PR DESCRIPTION
## Summary
- define `HttpClientError` enumeration and `httpClientErrorToString` utility
- use `HttpClientError` in `AsyncHttpClient` instead of magic error numbers
- document and exemplify the new error codes across README and examples

## Testing
- `python3 test_fix.py`


------
https://chatgpt.com/codex/tasks/task_b_689ebde1d8388323a1c66717175b9cf4