### PR TITLE
Add conditional timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,15 @@ void setup() {
 }
 
 void loop() {
+#if !ASYNC_TCP_HAS_TIMEOUT
+    client.loop();
+#endif
     delay(1000);
 }
 ```
+
+If your AsyncTCP library does not provide native timeout support (`setTimeout`),
+remember to call `client.loop()` regularly to handle manual timeout checks.
 
 ## API Reference
 

--- a/examples/CompileTest/CompileTest.ino
+++ b/examples/CompileTest/CompileTest.ino
@@ -100,6 +100,9 @@ void testHttpMethodsCompilation() {
 }
 
 void loop() {
+#if !ASYNC_TCP_HAS_TIMEOUT
+    client.loop();
+#endif
     // Simple heartbeat to show the program is running
     static unsigned long lastHeartbeat = 0;
     unsigned long now = millis();

--- a/examples/CustomHeaders/CustomHeaders.ino
+++ b/examples/CustomHeaders/CustomHeaders.ino
@@ -71,5 +71,8 @@ void setup() {
 }
 
 void loop() {
+#if !ASYNC_TCP_HAS_TIMEOUT
+    client.loop();
+#endif
     delay(1000);
 }

--- a/examples/MultipleRequests/MultipleRequests.ino
+++ b/examples/MultipleRequests/MultipleRequests.ino
@@ -72,5 +72,8 @@ void setup() {
 }
 
 void loop() {
+#if !ASYNC_TCP_HAS_TIMEOUT
+    client.loop();
+#endif
     delay(1000);
 }

--- a/examples/PostWithData/PostWithData.ino
+++ b/examples/PostWithData/PostWithData.ino
@@ -39,5 +39,8 @@ void setup() {
 }
 
 void loop() {
+#if !ASYNC_TCP_HAS_TIMEOUT
+    client.loop();
+#endif
     delay(1000);
 }

--- a/examples/SimpleGet/SimpleGet.ino
+++ b/examples/SimpleGet/SimpleGet.ino
@@ -29,5 +29,8 @@ void setup() {
 }
 
 void loop() {
+#if !ASYNC_TCP_HAS_TIMEOUT
+    client.loop();
+#endif
     delay(1000);
 }


### PR DESCRIPTION
## Summary
- Use AsyncTCP `setTimeout` when available and register timeout callback
- Fall back to manual timer with `loop()` when `setTimeout` is missing
- Document and exemplify `client.loop()` only for builds without native timeout support

## Testing
- `make test` *(fails: HTTPClientError)*
- `make test-examples` *(fails: HTTPClientError)*

